### PR TITLE
Fix template definition to allow split values.

### DIFF
--- a/semapv-terms.owl
+++ b/semapv-terms.owl
@@ -312,7 +312,8 @@
 
     <owl:Class rdf:about="https://w3id.org/semapv/vocab/Matching">
         <rdfs:subClassOf rdf:resource="https://w3id.org/semapv/vocab/MappingActivity"/>
-        <skos:altLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">matching operation|matching task</skos:altLabel>
+        <skos:altLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">matching operation</skos:altLabel>
+        <skos:altLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">matching task</skos:altLabel>
         <skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">An process that results in a mapping between a subject and an object entity.</skos:definition>
         <skos:example rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The label of a subject entity matches to an exact synonym of an object entity.</skos:example>
         <skos:prefLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">matching process</skos:prefLabel>

--- a/semapv-terms.tsv
+++ b/semapv-terms.tsv
@@ -1,5 +1,5 @@
 IRI	skos:prefLabel	skos:definition	dc:source	skos:example	rdfs:comment	altLabel	Parent
-ID	A skos:prefLabel	A skos:definition	A dc:source	A skos:example	A rdfs:comment	A skos:altLabel	SC %
+ID	A skos:prefLabel	A skos:definition	A dc:source	A skos:example	A rdfs:comment	A skos:altLabel SPLIT=|	SC %
 semapv:MappingActivity	mapping activity	A process that relates to the creation, confirmation, rejection or curation of a mapping.		Matching is a mapping activity that results in the creating of a mapping; mapping review is an activity that results in the confirmation of a mapping.			
 semapv:Matching	matching process	An process that results in a mapping between a subject and an object entity.		The label of a subject entity matches to an exact synonym of an object entity.		matching operation|matching task	semapv:MappingActivity
 semapv:Mapping	mapping	A triple <s,p,o> comprising a subject entity s, an object entity o and a mapping predicate p.		The subject entity NCI:C9305 is mapped to the object entity ICD10:C80.9 using the skos:relatedMatch mapping predicate.			

--- a/semapv.owl
+++ b/semapv.owl
@@ -341,7 +341,8 @@
 
     <owl:Class rdf:about="https://w3id.org/semapv/vocab/Matching">
         <rdfs:subClassOf rdf:resource="https://w3id.org/semapv/vocab/MappingActivity"/>
-        <skos:altLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">matching operation|matching task</skos:altLabel>
+        <skos:altLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">matching operation</skos:altLabel>
+        <skos:altLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">matching task</skos:altLabel>
         <skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string">An process that results in a mapping between a subject and an object entity.</skos:definition>
         <skos:example rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The label of a subject entity matches to an exact synonym of an object entity.</skos:example>
         <skos:prefLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">matching process</skos:prefLabel>


### PR DESCRIPTION
This commit fixes the `semapv-terms.tsv` template to allow split values ("SPLIT=|") in the `altLabel` column, since at least one term makes use of the "|" syntax to specify more than one alternative label.