### PR TITLE
Change license to cc-0

### DIFF
--- a/semapv-metadata.owl
+++ b/semapv-metadata.owl
@@ -12,7 +12,7 @@ Prefix(dcterms:=<http://purl.org/dc/terms/>)
 Ontology(<https://w3id.org/semapv/semapv.owl>
 
 Annotation(dcterms:description "The Semantic Mapping Vocabulary provides and defines terms used for creating and maintaining semantic mappings, in particular mapping metadata.")
-Annotation(dcterms:license <https://creativecommons.org/licenses/by/4.0/>)
+Annotation(dcterms:license <https://creativecommons.org/publicdomain/zero/1.0/>)
 Annotation(dcterms:title "Semantic Mapping Vocabulary")
 
 Declaration(AnnotationProperty(dcterms:description))


### PR DESCRIPTION
There is no need to use CC-BY in this case. CC-zero is much easier to process, also for efforts such as wikidata.